### PR TITLE
Remove empty lines from source files

### DIFF
--- a/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
+++ b/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
@@ -174,6 +174,15 @@ public class StringsFileUpdater {
     )
   }
 
+  public func removeEmptyLines(separateWithEmptyLine: Bool, keepWhitespaceSurroundings: Bool = false) {
+    let translations = findTranslations(inString: oldContentString)
+    rewriteFile(
+        with: translations,
+        keepWhitespaceSurroundings: keepWhitespaceSurroundings,
+        separateWithEmptyLine: separateWithEmptyLine
+    )
+  }
+
   private func translationEntrySortingClosure(lhs: TranslationEntry, rhs: TranslationEntry) -> Bool {
     // ensure keys with empty values are appended to the end
     if lhs.value.isEmpty == rhs.value.isEmpty {
@@ -559,5 +568,9 @@ extension String {
 
   var normalized: String {
     return folding(options: [.diacriticInsensitive, .caseInsensitive], locale: Locale(identifier: "en"))
+  }
+
+  func normalized(_ locale: Locale) -> String {
+    return folding(options: [], locale: locale)
   }
 }

--- a/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
+++ b/Sources/BartyCrouchKit/FileHandling/StringsFileUpdater.swift
@@ -569,8 +569,4 @@ extension String {
   var normalized: String {
     return folding(options: [.diacriticInsensitive, .caseInsensitive], locale: Locale(identifier: "en"))
   }
-
-  func normalized(_ locale: Locale) -> String {
-    return folding(options: [], locale: locale)
-  }
 }

--- a/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
+++ b/Sources/BartyCrouchKit/OldCommandLine/CommandLineActor.swift
@@ -200,6 +200,11 @@ public class CommandLineActor {
           let stringsFileUpdater = StringsFileUpdater(path: filePath)
           stringsFileUpdater?.sortByKeys(separateWithEmptyLine: separateWithEmptyLine)
         }
+      } else if !separateWithEmptyLine {
+        for filePath in allStringsFilePaths {
+          let stringsFileUpdater = StringsFileUpdater(path: filePath)
+          stringsFileUpdater?.removeEmptyLines(separateWithEmptyLine: separateWithEmptyLine)
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes #

## Proposed Changes

When using the following options the empty lines was not removed in the source files

 ```toml
[update.normalize]
paths = ["./Sources"]
sourceLocale = "sv"
separateWithEmptyLine = false
sortByKeys = false
harmonizeWithSource = true
```

This PR make sure to rewrite the source files without empty lines in all cases when `separateWithEmptyLine` is disabled