### PR TITLE
Document how to localized code strings of type LocalizedStringResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ self.title = L10n.Onboarding.FirstPage.headerTitle
 
 NOTE: As of version 4.x of BartyCrouch *formatted* localized Strings are not supported by this automatic feature.
 
-### Localizing strings of `LocalizableStringResource` type (AppIntents, SwiftUI, ...)
+### Localizing strings of `LocalizableStringResource` type (AppIntents, ...)
 
 Historically, Apple platforms used `CFCopyLocalizedString`, and `NSLocalizedString` macros and their variants, to mark strings used in code to be localized, and to load their localized versions during runtime from `Localizable.strings` file.
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ tasks = ["interfaces", "code", "transform", "normalize"]
 - `localizablePaths`: The enclosing path(s) containing the localized `Localizable.strings` files.
 - `defaultToKeys`: Add new keys both as key and value.
 - `additive`: Prevents cleaning up keys not found in code.
-- `customFunction`: Use alternative name to `NSLocalizedString`.
+- `customFunction`: Use alternative name to search for strings to localize, in addition to `NSLocalizedString`, and `CFCopyLocalizedString`. If not specified, look for `LocalizedStringResource`.
 - `customLocalizableName`: Use alternative name for `Localizable.strings`.
 - `unstripped`: Keeps whitespaces at beginning & end of Strings files.
 - `plistArguments`: Use a plist file to store all the code files for the ExtractLocStrings tool. (Recommended for large projects.)
@@ -354,6 +354,40 @@ self.title = L10n.Onboarding.FirstPage.headerTitle
 * Not as fast as `code` since [SwiftSyntax](https://github.com/apple/swift-syntax) currently isn't [particularly fast](https://www.jpsim.com/evaluating-swiftsyntax-for-use-in-swiftlint/). (But this should improve over time!)
 
 NOTE: As of version 4.x of BartyCrouch *formatted* localized Strings are not supported by this automatic feature.
+
+### Localizing strings of `LocalizableStringResource` type (AppIntents, SwiftUI, ...)
+
+Historically, Apple platforms used `CFCopyLocalizedString`, and `NSLocalizedString` macros and their variants, to mark strings used in code to be localized, and to load their localized versions during runtime from `Localizable.strings` file.
+
+Since introduction of SwiftUI, the localized strings in code are typically typed as `LocalizedStringResource`, and are no longer marked explicitely.
+
+Let's examine this snippet of AppIntents code:
+
+```
+struct ExportAllTransactionsIntent: AppIntent {
+    static var title: LocalizedStringResource = "Export all transactions"
+    
+    static var description =
+        IntentDescription("Exports your transaction history as CSV data.")
+}
+```
+
+In the example above, both the `"Export all transactions"`, and `"Exports your transaction history as CSV data."` are actually `StaticString` instances that will be converted during compilation into `LocalizedStringResource` instances, and will lookup their respective localizations during runtime from `Localized.strings` file the same way as when using `NSLocalizedString` in the past. The only exception being that such strings are not marked explicitly, and require swift compiler to parse and extract such strings for localization. This is what Xcode does from version 13 when using `Product -> Export Localizations...` option.
+
+In order to continue translating these strings with `bartycrouch` it is required to mark them explicitely with `LocalizedStringResource(_: String, comment: String)` call, and specify `customFunction="LocalizedStringResource"` in `code` task options.
+
+The example AppIntents code that can be localized with `bartycrouch` will look like this:
+
+```
+struct ExportAllTransactionsIntent: AppIntent {
+    static var title: LocalizedStringResource = LocalizedStringResource("Export all transactions", comment: "")
+    
+    static var description =
+        IntentDescription(LocalizedStringResource("Exports your transaction history as CSV data.", comment: ""))
+}
+```
+
+Note that you must use the full form of `LocalizedStringResource(_: StaticString, comment: StaticString)` for the `bartycrouch`, or more specifically for the `extractLocStrings` (see `xcrun extractLocStrings`) to properly parse the strings.
 
 ### Build Script
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ tasks = ["interfaces", "code", "transform", "normalize"]
 - `localizablePaths`: The enclosing path(s) containing the localized `Localizable.strings` files.
 - `defaultToKeys`: Add new keys both as key and value.
 - `additive`: Prevents cleaning up keys not found in code.
-- `customFunction`: Use alternative name to search for strings to localize, in addition to `NSLocalizedString`, and `CFCopyLocalizedString`. If not specified, look for `LocalizedStringResource`.
+- `customFunction`: Use alternative name to search for strings to localize, in addition to `NSLocalizedString`, and `CFCopyLocalizedString`. Defaults to `LocalizedStringResource`.
 - `customLocalizableName`: Use alternative name for `Localizable.strings`.
 - `unstripped`: Keeps whitespaces at beginning & end of Strings files.
 - `plistArguments`: Use a plist file to store all the code files for the ExtractLocStrings tool. (Recommended for large projects.)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The example AppIntents code that can be localized with `bartycrouch` will look l
 
 ```
 struct ExportAllTransactionsIntent: AppIntent {
-    static var title: LocalizedStringResource = LocalizedStringResource("Export all transactions", comment: "")
+    static var title = LocalizedStringResource("Export all transactions", comment: "")
     
     static var description =
         IntentDescription(LocalizedStringResource("Exports your transaction history as CSV data.", comment: ""))

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ NOTE: As of version 4.x of BartyCrouch *formatted* localized Strings are not sup
 
 Historically, Apple platforms used `CFCopyLocalizedString`, and `NSLocalizedString` macros and their variants, to mark strings used in code to be localized, and to load their localized versions during runtime from `Localizable.strings` file.
 
-Since introduction of SwiftUI, the localized strings in code are typically typed as `LocalizedStringResource`, and are no longer marked explicitely.
+Since introduction of the AppIntents framework, the localized strings in code can also be typed as `LocalizedStringResource`, and are no longer marked explicitly.
 
 Let's examine this snippet of AppIntents code:
 

--- a/Sources/BartyCrouchConfiguration/Options/UpdateOptions/CodeOptions.swift
+++ b/Sources/BartyCrouchConfiguration/Options/UpdateOptions/CodeOptions.swift
@@ -27,7 +27,7 @@ extension CodeOptions: TomlCodable {
       localizablePaths: toml.filePaths(update, code, singularKey: "localizablePath", pluralKey: "localizablePaths"),
       defaultToKeys: toml.bool(update, code, "defaultToKeys") ?? false,
       additive: toml.bool(update, code, "additive") ?? true,
-      customFunction: toml.string(update, code, "customFunction"),
+      customFunction: toml.string(update, code, "customFunction") ?? "LocalizedStringResource",
       customLocalizableName: toml.string(update, code, "customLocalizableName"),
       unstripped: toml.bool(update, code, "unstripped") ?? false,
       plistArguments: toml.bool(update, code, "plistArguments") ?? true,

--- a/Tests/BartyCrouchConfigurationTests/ConfigurationTests.swift
+++ b/Tests/BartyCrouchConfigurationTests/ConfigurationTests.swift
@@ -117,6 +117,7 @@ class ConfigurationTests: XCTestCase {
       XCTAssertEqual(configuration.updateOptions.code.customLocalizableName, "MyOwnLocalizable")
       XCTAssertEqual(configuration.updateOptions.code.defaultToKeys, true)
       XCTAssertEqual(configuration.updateOptions.code.unstripped, true)
+      XCTAssertEqual(configuration.updateOptions.code.overrideComments, false)
 
       XCTAssertEqual(configuration.updateOptions.transform.codePaths, ["Sources"])
       XCTAssertEqual(configuration.updateOptions.transform.localizablePaths, ["Sources/SupportingFiles"])
@@ -168,6 +169,7 @@ class ConfigurationTests: XCTestCase {
       unstripped = true
       plistArguments = true
       ignoreKeys = ["#bartycrouch-ignore!", "#bc-ignore!", "#i!"]
+      overrideComments = false
 
       [update.transform]
       codePaths = ["."]

--- a/Tests/BartyCrouchConfigurationTests/ConfigurationTests.swift
+++ b/Tests/BartyCrouchConfigurationTests/ConfigurationTests.swift
@@ -21,7 +21,7 @@ class ConfigurationTests: XCTestCase {
       XCTAssertEqual(configuration.updateOptions.code.codePaths, ["."])
       XCTAssertEqual(configuration.updateOptions.code.localizablePaths, ["."])
       XCTAssertEqual(configuration.updateOptions.code.additive, true)
-      XCTAssertEqual(configuration.updateOptions.code.customFunction, nil)
+      XCTAssertEqual(configuration.updateOptions.code.customFunction, "LocalizedStringResource")
       XCTAssertEqual(configuration.updateOptions.code.customLocalizableName, nil)
       XCTAssertEqual(configuration.updateOptions.code.defaultToKeys, false)
       XCTAssertEqual(configuration.updateOptions.code.unstripped, false)


### PR DESCRIPTION
Fixes https://github.com/FlineDev/BartyCrouch/issues/265

## Proposed Changes

  - When no `update.code.customFunction` is specified, use `LocalizedStringResource` by default, in addition to `NSLocalizedString`, and `CFCopyLocalizedString`.
  - Document how to use `LocalizedStringResource(_: StaticString, comment: StaticString)` initializer to localize SwiftUI and AppIntents code.

## Alternatives Considered

When examining manpage for `genstrings(1)` and help obtained via `xcrun extractLocStrings`, both commands support a `-SwiftUI` argument that should parse SwiftUI `Text()` initializer. Therefore it may appear useful to expose `-SwiftUI` argument via `update.code` configuration.

I have not used the `-SwiftUI` option and do not know how reliable or useful is/would be in this case. And I am not sure what other instances apart from `Text()` will be recognized. Perhaps the `xcrun extractLocStrings` may actually analyze the `.swift` files and precompile them to recognize all use of `LocalizedStringResource` and extract those as well. Needs more investigation. 
