### PR TITLE
Fix that DeepL translation doesn't work

### DIFF
--- a/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
+++ b/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
@@ -77,7 +77,7 @@ extension DeepLApi: Endpoint {
   }
 
   var headers: [String: String] {
-    ["Content-Type": "application/json"]
+    [:]
   }
 
   static func baseUrl(for apiType: ApiType) -> URL {


### PR DESCRIPTION
(No related issues.)

## Proposed Changes

Currently, BartyCrouch always fails to call DeepL API's URL (https://api-free.deepl.com/v2/translate). 400 error is returned and the response body includes this:

```json
{
	"message": "Invalid JSON request."
}
```

This seems to happen because `Content-Type: application/json` is specified. Since this is a GET request, I think we shouldn't include it. So I just deleted it.

## Other

According to https://www.deepl.com/en/docs-api, BartyCrouch should actually call this URL as a POST request. It even works as a GET request as of now, but I don't know why. Historical reasons, maybe? Sorry, I don't have enough time to work 🙂, but I suggest following that documentation so that no future problems.