### PR TITLE
Cocoapods: fix support for non-macOS platforms

### DIFF
--- a/BartyCrouch.podspec
+++ b/BartyCrouch.podspec
@@ -20,7 +20,10 @@ Pod::Spec.new do |s|
   s.source         = { :http => "#{s.homepage}/releases/download/#{s.version}/portable_bartycrouch.zip" }
   s.preserve_paths = "*"
 
-  s.osx.deployment_target  = '13.0'
-  s.swift_version          = '5.7'
+  s.ios.deployment_target     = '9.0'
+  s.macos.deployment_target   = '13.0'
+  s.tvos.deployment_target    = '9.0'
+  s.watchos.deployment_target = '2.0'
+  s.swift_version             = '5.7'
 
 end


### PR DESCRIPTION
Based on https://github.com/realm/SwiftLint/blob/main/SwiftLint.podspec
Fixes #273

Note that a new release will need to be created on CocoaPods, so we may want to release this as a tiny bug-fix version (i.e. 4.14.1).