### PR TITLE
Fix DeepL query items

### DIFF
--- a/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
+++ b/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
@@ -57,13 +57,21 @@ extension DeepLApi: Endpoint {
   var method: HttpMethod {
     switch self {
     case .translate(let texts, let sourceLanguage, let targetLanguage, let authKey):
-      let textEntries = texts.map { "text=\($0.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!)" }
-        .joined(separator: "&")
-      let authKeyEntry = "auth_key=\(authKey)"
-      let sourceLanguageEntry = "source_lang=\(sourceLanguage.deepLParameterValue)"
-      let targetLanguageEntry = "target_lang=\(targetLanguage.deepLParameterValue)"
-      let bodyString = [authKeyEntry, sourceLanguageEntry, targetLanguageEntry, textEntries].joined(separator: "&")
-      return .post(body: bodyString.data(using: .utf8)!)
+      
+      let authKeyItem = URLQueryItem(name: "auth_key", value: authKey)
+      let textItem = URLQueryItem(name: "text", value: text)
+      let targetLangItem = URLQueryItem(name: "target_lang", value: targetLanguage.deepLParameterValue)
+      let sourceLangItem = URLQueryItem(name: "source_lang", value: sourceLang.deepLParameterValue)
+      let formalityItem = URLQueryItem(name: "formality", value: "prefer_less")
+      
+      var components = URLComponents()
+      components.queryItems = [authKeyItem, textItem, targetLangItem, sourceLangItem, formalityItem].compactMap { $0 }
+      
+      guard let queryItemsString = comp.string else {
+          fatalError("Invalid arguments.")
+      }
+                
+      return .post(body: queryItemsString.suffix(queryItemsString.count - 1).data(using: .utf8)!)      
     }
   }
 

--- a/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
+++ b/Sources/BartyCrouchTranslator/DeeplApi/DeepLApi.swift
@@ -59,19 +59,22 @@ extension DeepLApi: Endpoint {
     case .translate(let texts, let sourceLanguage, let targetLanguage, let authKey):
       
       let authKeyItem = URLQueryItem(name: "auth_key", value: authKey)
-      let textItem = URLQueryItem(name: "text", value: text)
+      let textItems = texts.map { URLQueryItem(name: "text", value: $0) }
       let targetLangItem = URLQueryItem(name: "target_lang", value: targetLanguage.deepLParameterValue)
-      let sourceLangItem = URLQueryItem(name: "source_lang", value: sourceLang.deepLParameterValue)
-      let formalityItem = URLQueryItem(name: "formality", value: "prefer_less")
+      let sourceLangItem = URLQueryItem(name: "source_lang", value: sourceLanguage.deepLParameterValue)
       
       var components = URLComponents()
-      components.queryItems = [authKeyItem, textItem, targetLangItem, sourceLangItem, formalityItem].compactMap { $0 }
+      components.queryItems = ([authKeyItem, targetLangItem, sourceLangItem] + textItems).compactMap { $0 }
       
-      guard let queryItemsString = comp.string else {
+      guard var queryItemsString = components.string else {
           fatalError("Invalid arguments.")
       }
+      // queryItemsString starts with a ? but post API expects the query string without leading ?
+      if queryItemsString.hasPrefix("?") {
+        queryItemsString.removeFirst()
+      }
                 
-      return .post(body: queryItemsString.suffix(queryItemsString.count - 1).data(using: .utf8)!)      
+      return .post(body: queryItemsString.data(using: .utf8)!)
     }
   }
 

--- a/Tests/BartyCrouchTranslatorTests/DeepLTranslatorApiTests.swift
+++ b/Tests/BartyCrouchTranslatorTests/DeepLTranslatorApiTests.swift
@@ -19,7 +19,7 @@ class DeepLTranslatorApiTests: XCTestCase {
 
     switch apiProvider.performRequestAndWait(on: endpoint, decodeBodyTo: DeepLTranslateResponse.self) {
     case let .success(translateResponses):
-      XCTAssertEqual(translateResponses.translations[0].text, "Wie alt bist du?")
+      XCTAssertEqual(translateResponses.translations[0].text, "Wie alt sind Sie?")
       XCTAssertEqual(translateResponses.translations[1].text, "Liebe")
 
     case let .failure(failure):

--- a/Tests/BartyCrouchTranslatorTests/DeepLTranslatorApiTests.swift
+++ b/Tests/BartyCrouchTranslatorTests/DeepLTranslatorApiTests.swift
@@ -19,7 +19,8 @@ class DeepLTranslatorApiTests: XCTestCase {
 
     switch apiProvider.performRequestAndWait(on: endpoint, decodeBodyTo: DeepLTranslateResponse.self) {
     case let .success(translateResponses):
-      XCTAssertEqual(translateResponses.translations[0].text, "Wie alt sind Sie?")
+      XCTAssertEqual(translateResponses.translations[0].text, "Wie alt bist du?")
+      XCTAssertEqual(translateResponses.translations[1].text, "Liebe")
 
     case let .failure(failure):
       XCTFail(failure.localizedDescription)


### PR DESCRIPTION
## Proposed Changes

  - translate was creating the query strings "by hand"
  - safer method is to use URLQueryItem and URLComponents
  - Careful: this does not handle special characters like `+`. DeepL still strips them out. (See section In-Text Markup: https://www.deepl.com/docs-api/translate-text/translate-text/ )
