### PR TITLE
Update SwiftSyntax to 508

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     .package(name: "Rainbow", url: "https://github.com/onevcat/Rainbow.git", from: "3.1.5"),
     .package(name: "SwiftCLI", url: "https://github.com/jakeheis/SwiftCLI.git", from: "6.0.3"),
     .package(name: "Toml", url: "https://github.com/jdfergason/swift-toml.git", .branch("master")),
-    .package(url: "https://github.com/apple/swift-syntax.git", .branch("0.50700.1")),
+    .package(url: "https://github.com/apple/swift-syntax.git", from: "508.0.0"),
 
     // A collection of tools for debugging, diffing, and testing your application's data structures.
     .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "0.3.0"),

--- a/Sources/BartyCrouchKit/FileHandling/SupportedLanguagesReader.swift
+++ b/Sources/BartyCrouchKit/FileHandling/SupportedLanguagesReader.swift
@@ -10,6 +10,7 @@ class SupportedLanguagesReader: SyntaxVisitor {
     typeName: String
   ) {
     self.typeName = typeName
+    super.init(viewMode: .sourceAccurate)
   }
 
   override func visit(_ enumDeclaration: EnumDeclSyntax) -> SyntaxVisitorContinueKind {


### PR DESCRIPTION
Fixes issues building with Xcode 14.3

Attempting to use bartycrouch via Mint would error with:
```
/private/var/folders/sv/knvktwjn467cm25718rm22mc0000gq/T/mint/github.com_FlineDev_BartyCrouch/.build/checkouts/swift-syntax/Sources/SwiftSyntax/SyntaxParser.swift:17:8: error: no such module '_InternalSwiftSyntaxParser'
```
Cloning this repo and attempting to build with `swift build --product bartycrouch` had the same result.

Updating SwiftSyntax resolved this.
