### PR TITLE
Don't ship lib_InternalSwiftSyntaxParser.dylib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,6 @@ bartycrouch_universal: $(SOURCES)
 install: bartycrouch
 	@install -d "$(bindir)" "$(libdir)"
 	@install "$(BUILDDIR)/release/bartycrouch" "$(bindir)"
-	@install ".build/artifacts/swift-syntax/_InternalSwiftSyntaxParser.xcframework/macos-arm64_x86_64/lib_InternalSwiftSyntaxParser.dylib" \
-		"$(libdir)"
-	@install_name_tool -change \
-		"@rpath/lib_InternalSwiftSyntaxParser.dylib" \
-		"$(libdir)/lib_InternalSwiftSyntaxParser.dylib" \
-		"$(bindir)/bartycrouch"
 
 .PHONY: portable_zip
 portable_zip: bartycrouch_universal
@@ -49,7 +43,6 @@ portable_zip: bartycrouch_universal
 	@zip -q -j "$(BUILDDIR)/Apple/Products/Release/portable_bartycrouch.zip" \
 		"$(TMP)/bartycrouch" \
 		"$(REPODIR)/LICENSE" \
-		".build/artifacts/swift-syntax/_InternalSwiftSyntaxParser.xcframework/macos-arm64_x86_64/lib_InternalSwiftSyntaxParser.dylib"
 	@echo "Portable ZIP created at: $(BUILDDIR)/Apple/Products/Release/portable_bartycrouch.zip"
 	@rm -rf $(TMP)
 


### PR DESCRIPTION
I'm hopeful this resolves the [brew CI failure](https://github.com/Homebrew/homebrew-core/pull/131567) with 4.15.0

It appears this doesn't exist, and isn't required, after the update to SwiftSyntax 508